### PR TITLE
[UPD] force to occur error message when cell is empty

### DIFF
--- a/base_import_log/i18n/ja_JP.po
+++ b/base_import_log/i18n/ja_JP.po
@@ -6,8 +6,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Odoo Server 8.0\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2015-10-30 11:10+0000\n"
-"PO-Revision-Date: 2015-10-30 11:10+0000\n"
+"POT-Creation-Date: 2015-11-06 01:59+0000\n"
+"PO-Revision-Date: 2015-11-06 01:59+0000\n"
 "Last-Translator: <>\n"
 "Language-Team: \n"
 "MIME-Version: 1.0\n"
@@ -53,11 +53,6 @@ msgstr "エラー"
 #: view:error.log:base_import_log.import_error_log_form
 msgid "Error Logs"
 msgstr "エラーログ"
-
-#. module: base_import_log
-#: field:error.log.line,row_no:0
-msgid "Excel Row Number"
-msgstr "Excel行番号"
 
 #. module: base_import_log
 #: selection:error.log,state:0
@@ -148,6 +143,11 @@ msgstr "モデル"
 #: field:error.log.line,order_group:0
 msgid "Order Group"
 msgstr "オーダグループ"
+
+#. module: base_import_log
+#: field:error.log.line,row_no:0
+msgid "Row Number"
+msgstr "行番号"
 
 #. module: base_import_log
 #: view:error.log:base_import_log.error_log_filter

--- a/base_import_log/models/error_log.py
+++ b/base_import_log/models/error_log.py
@@ -22,7 +22,7 @@ class error_log_lines(models.Model):
     _name = 'error.log.line'
 
     error_name =  fields.Text('Error')
-    row_no = fields.Integer('Excel Row Number')
+    row_no = fields.Integer('Row Number')
     order_group = fields.Char('Order Group')
     log_id = fields.Many2one('error.log', string='Log')
     

--- a/picking_import/i18n/ja_JP.po
+++ b/picking_import/i18n/ja_JP.po
@@ -6,8 +6,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Odoo Server 8.0\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2015-11-03 05:36+0000\n"
-"PO-Revision-Date: 2015-11-03 05:36+0000\n"
+"POT-Creation-Date: 2015-11-06 02:03+0000\n"
+"PO-Revision-Date: 2015-11-06 02:03+0000\n"
 "Last-Translator: <>\n"
 "Language-Team: \n"
 "MIME-Version: 1.0\n"
@@ -26,7 +26,7 @@ msgstr " 見つかりません!"
 #: code:addons/picking_import/wizard/import_picking.py:219
 #, python-format
 msgid " Not Ready to Transfer!"
-msgstr " 移動待ちではありません!"
+msgstr " 転送の準備ができていません!"
 
 #. module: picking_import
 #: code:addons/picking_import/wizard/import_picking.py:248
@@ -115,8 +115,8 @@ msgstr "最終更新日"
 #. module: picking_import
 #: code:addons/picking_import/wizard/import_picking.py:298
 #, python-format
-msgid "Order Number is empty at Line: "
-msgstr "次の行でオーダー番号が空です: "
+msgid "Order Number is empty!"
+msgstr "オーダー番号が空です!"
 
 #. module: picking_import
 #: field:stock.picking,order_ref:0
@@ -142,7 +142,7 @@ msgstr "ピッキングリスト"
 #: code:addons/picking_import/wizard/import_picking.py:252
 #, python-format
 msgid "Picking State is "
-msgstr "ピッキングのステータス: "
+msgstr "ピッキングのステータスは "
 
 #. module: picking_import
 #: field:error.log,picking_type:0

--- a/picking_import/wizard/import_picking.py
+++ b/picking_import/wizard/import_picking.py
@@ -47,14 +47,14 @@ class import_picking(models.TransientModel):
                                                         'model_id': model.id,
                                                         'picking_type': error_line_vals['picking_type']}).id
             error_line_id = self.env['error.log.line'].create({
-                                        'row_no' : row_no + 1,
+                                        'row_no' : row_no,
                                         'order_group' : order_group_value,
                                         'error_name': error_line_vals['error_name'],
                                         'log_id' : error_log_id
                                     })
         elif error_line_vals['error']:
             error_line_id = self.env['error.log.line'].create({
-                                        'row_no' : row_no + 1,
+                                        'row_no' : row_no,
                                         'order_group' : order_group_value,
                                         'error_name': error_line_vals['error_name'],
                                         'log_id' : error_log_id
@@ -295,7 +295,7 @@ class import_picking(models.TransientModel):
                         successed_picking_ids = self._purchase_picking_process(order_number, error_line_vals)
                         purchase_picking_ids.extend(successed_picking_ids)
                 else:
-                    error_line_vals['error_name'] = _('Order Number is empty at Line: ') + str(line)
+                    error_line_vals['error_name'] = _('Order Number is empty!') + '\n'
                     error_line_vals['error'] = True
                     error_line_vals.update({'picking_type': self.picking_type })
 

--- a/purchase_order_import/i18n/ja_JP.po
+++ b/purchase_order_import/i18n/ja_JP.po
@@ -6,8 +6,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Odoo Server 8.0\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2015-11-03 08:57+0000\n"
-"PO-Revision-Date: 2015-11-03 08:57+0000\n"
+"POT-Creation-Date: 2015-11-06 03:01+0000\n"
+"PO-Revision-Date: 2015-11-06 03:01+0000\n"
 "Last-Translator: <>\n"
 "Language-Team: \n"
 "MIME-Version: 1.0\n"
@@ -154,6 +154,12 @@ msgid "Order Reference"
 msgstr "オーダー参照"
 
 #. module: purchase_order_import
+#: code:addons/purchase_order_import/wizard/import_purchase.py:248
+#, python-format
+msgid "Partner is empty!"
+msgstr "仕入先が空です!"
+
+#. module: purchase_order_import
 #: code:addons/purchase_order_import/wizard/import_purchase.py:66
 #, python-format
 msgid "Partner: "
@@ -178,16 +184,22 @@ msgid "Please select Supplier Payment Journal."
 msgstr "仕入先支払仕訳帳を選択してください。"
 
 #. module: purchase_order_import
-#: code:addons/purchase_order_import/wizard/import_purchase.py:276
+#: code:addons/purchase_order_import/wizard/import_purchase.py:262
 #, python-format
-msgid "Price Unit not less then zero!"
-msgstr "単価が負の値になっています!"
+msgid "Pricelist is empty!"
+msgstr "価格表が空です!"
 
 #. module: purchase_order_import
 #: code:addons/purchase_order_import/wizard/import_purchase.py:86
 #, python-format
 msgid "Pricelist: "
 msgstr "価格表: "
+
+#. module: purchase_order_import
+#: code:addons/purchase_order_import/wizard/import_purchase.py:255
+#, python-format
+msgid "Product is empty!"
+msgstr "製品が空です!"
 
 #. module: purchase_order_import
 #: code:addons/purchase_order_import/wizard/import_purchase.py:76
@@ -221,10 +233,16 @@ msgid "Purhcase Import Defaults"
 msgstr "購買データインポートデフォルト"
 
 #. module: purchase_order_import
-#: code:addons/purchase_order_import/wizard/import_purchase.py:271
+#: code:addons/purchase_order_import/wizard/import_purchase.py:283
 #, python-format
-msgid "Quantity not less then zero!"
-msgstr "数量が負の値になっています!"
+msgid "Quantity is empty!"
+msgstr "数量が空です!"
+
+#. module: purchase_order_import
+#: code:addons/purchase_order_import/wizard/import_purchase.py:289
+#, python-format
+msgid "Quantity not less than zero!"
+msgstr "数量は0以下の値を取ることはできません!"
 
 #. module: purchase_order_import
 #: field:error.log,purchase_order_ids:0
@@ -253,6 +271,24 @@ msgstr "税: "
 #: view:import.purchase:purchase_order_import.view_purchase_import_wizard
 msgid "This wizard will create purchase orders using imported .csv file. It will also validate purchase order, validate invoice and pay the invoice."
 msgstr "このウィザードは、インポートされた.csvファイルを使って発注を作成します。また、発注確認、請求書の検証、請求書の支払を行います。"
+
+#. module: purchase_order_import
+#: code:addons/purchase_order_import/wizard/import_purchase.py:294
+#, python-format
+msgid "Unit Price is empty!"
+msgstr "単価が空です!"
+
+#. module: purchase_order_import
+#: code:addons/purchase_order_import/wizard/import_purchase.py:300
+#, python-format
+msgid "Unit Price not less than zero!"
+msgstr "単価は0以下の値を取ることはできません!"
+
+#. module: purchase_order_import
+#: code:addons/purchase_order_import/wizard/import_purchase.py:271
+#, python-format
+msgid "Warehouse is empty!"
+msgstr "倉庫が空です!"
 
 #. module: purchase_order_import
 #: code:addons/purchase_order_import/wizard/import_purchase.py:95

--- a/purchase_order_import/wizard/import_purchase.py
+++ b/purchase_order_import/wizard/import_purchase.py
@@ -126,14 +126,14 @@ class import_purchase(models.TransientModel):
                                                         'state': 'failed',
                                                         'model_id': model.id}).id
             error_line_id = self.env['error.log.line'].create({
-                                        'row_no' : row_no + 1,
+                                        'row_no' : row_no,
                                         'order_group' : order_group_value,
                                         'error_name': error_line_vals['error_name'],
                                         'log_id' : error_log_id
                                     })
         elif error_line_vals['error']:
             error_line_id = self.env['error.log.line'].create({
-                                        'row_no' : row_no + 1,
+                                        'row_no' : row_no,
                                         'order_group' : order_group_value,
                                         'error_name': error_line_vals['error_name'],
                                         'log_id' : error_log_id
@@ -244,21 +244,33 @@ class import_purchase(models.TransientModel):
                 
                 error_line_vals = {'error_name' : '', 'error': False}
                 partner_value = row[partner_id].strip()
-                if partner_value:
+                if not partner_value:
+                    error_line_vals['error_name'] = error_line_vals['error_name'] + _('Partner is empty!') + '\n'
+                    error_line_vals['error'] = True
+                else:
                     self._get_partner_dict(partner_value, partner_dict, error_line_vals)
                 
                 product_id_value = row[product_id].strip()
-                if product_id_value:
+                if not product_id_value:
+                    error_line_vals['error_name'] = error_line_vals['error_name'] + _('Product is empty!') + '\n'
+                    error_line_vals['error'] = True
+                else:
                     self._get_product_dict(product_id_value, product_dict, error_line_vals)
                 
                 pricelist_value = row[pricelist_id].strip()
-                if pricelist_value:
+                if not pricelist_value:
+                    error_line_vals['error_name'] = error_line_vals['error_name'] + _('Pricelist is empty!') + '\n'
+                    error_line_vals['error'] = True
+                else:
                     self._get_pricelist_dict(pricelist_value, pricelist_dict, error_line_vals)
                 
                 invoice_method = self.invoice_method
                 
                 warehouse_value = row[warehouse_id].strip()
-                if warehouse_value:
+                if not warehouse_value:
+                    error_line_vals['error_name'] = error_line_vals['error_name'] + _('Warehouse is empty!') + '\n'
+                    error_line_vals['error'] = True
+                else:
                     self._get_picking_dict(warehouse_value, picking_dict, error_line_vals)
                 
                 taxes = []
@@ -266,14 +278,26 @@ class import_purchase(models.TransientModel):
                 if tax_from_chunk:
                     self._get_taxes(tax_from_chunk, taxes, error_line_vals)
 
-                qty = float(row[product_qty].strip())
-                if qty < 0:
-                    error_line_vals['error_name'] = error_line_vals['error_name'] + _('Quantity not less then zero!') + '\n'
+                qty = row[product_qty].strip()
+                if not qty:
+                    error_line_vals['error_name'] = error_line_vals['error_name'] + _('Quantity is empty!') + '\n'
+                    error_line_vals['error'] = True
+                else:
+                    qty = float(qty)
+                
+                if qty <= 0:
+                    error_line_vals['error_name'] = error_line_vals['error_name'] + _('Quantity not less than zero!') + '\n'
                     error_line_vals['error'] = True
                 
-                price_unit_value = float(row[price_unit].strip())
-                if price_unit_value < 0:
-                    error_line_vals['error_name'] = error_line_vals['error_name'] + _('Price Unit not less then zero!') + '\n'
+                price_unit_value = row[price_unit].strip()
+                if not price_unit_value:
+                    error_line_vals['error_name'] = error_line_vals['error_name'] + _('Unit Price is empty!') + '\n'
+                    error_line_vals['error'] = True
+                else:
+                    price_unit_value = float(price_unit_value)
+                
+                if price_unit_value <= 0:
+                    error_line_vals['error_name'] = error_line_vals['error_name'] + _('Unit Price not less than zero!') + '\n'
                     error_line_vals['error'] = True
                 
                 error_log_id = self._update_error_log(error_log_id, error_line_vals, ir_attachment, model, line, order_group_value)

--- a/sale_order_import/i18n/ja_JP.po
+++ b/sale_order_import/i18n/ja_JP.po
@@ -6,8 +6,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Odoo Server 8.0\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2015-11-03 08:57+0000\n"
-"PO-Revision-Date: 2015-11-03 08:57+0000\n"
+"POT-Creation-Date: 2015-11-06 03:01+0000\n"
+"PO-Revision-Date: 2015-11-06 03:01+0000\n"
 "Last-Translator: <>\n"
 "Language-Team: \n"
 "MIME-Version: 1.0\n"
@@ -171,6 +171,12 @@ msgid "Order Reference"
 msgstr "オーダー参照"
 
 #. module: sale_order_import
+#: code:addons/sale_order_import/wizard/import_sale.py:269
+#, python-format
+msgid "Partner is empty!"
+msgstr "顧客が空です!"
+
+#. module: sale_order_import
 #: code:addons/sale_order_import/wizard/import_sale.py:83
 #, python-format
 msgid "Partner: "
@@ -183,10 +189,10 @@ msgid "Please prepare a CSV file with UTF-8 encoding.!"
 msgstr "UTF-8エンコーディングの.csvファイルを用意してください!"
 
 #. module: sale_order_import
-#: code:addons/sale_order_import/wizard/import_sale.py:295
+#: code:addons/sale_order_import/wizard/import_sale.py:283
 #, python-format
-msgid "Price Unit not less then zero!"
-msgstr "単価が負の値になっています!"
+msgid "Pricelist is empty!"
+msgstr "価格表が空です!"
 
 #. module: sale_order_import
 #: code:addons/sale_order_import/wizard/import_sale.py:103
@@ -195,16 +201,28 @@ msgid "Pricelist: "
 msgstr "価格表: "
 
 #. module: sale_order_import
+#: code:addons/sale_order_import/wizard/import_sale.py:276
+#, python-format
+msgid "Product is empty!"
+msgstr "製品が空です!"
+
+#. module: sale_order_import
 #: code:addons/sale_order_import/wizard/import_sale.py:93
 #, python-format
 msgid "Product: "
 msgstr "製品: "
 
 #. module: sale_order_import
-#: code:addons/sale_order_import/wizard/import_sale.py:290
+#: code:addons/sale_order_import/wizard/import_sale.py:302
 #, python-format
-msgid "Quantity not less then zero!"
-msgstr "数量が負の値になっています!"
+msgid "Quantity is empty!"
+msgstr "数量が空です!"
+
+#. module: sale_order_import
+#: code:addons/sale_order_import/wizard/import_sale.py:308
+#, python-format
+msgid "Quantity not less than zero!"
+msgstr "数量は0以下の値を取ることはできません!"
 
 #. module: sale_order_import
 #: field:error.log,sale_order_ids:0
@@ -248,6 +266,24 @@ msgstr "税: "
 #: view:import.sale:sale_order_import.view_sale_import_wizard
 msgid "This wizard will create sales orders using imported .csv file. It will also validate sales order, validate invoice and pay the invoice."
 msgstr "このウィザードは、インポートされた.csvファイルを使って受注を作成します。また、受注確認、請求書の検証、請求書の支払を行います。"
+
+#. module: sale_order_import
+#: code:addons/sale_order_import/wizard/import_sale.py:313
+#, python-format
+msgid "Unit Price is empty!"
+msgstr "単価が空です!"
+
+#. module: sale_order_import
+#: code:addons/sale_order_import/wizard/import_sale.py:319
+#, python-format
+msgid "Unit Price not less than zero!"
+msgstr "単価は0以下の値を取ることはできません!"
+
+#. module: sale_order_import
+#: code:addons/sale_order_import/wizard/import_sale.py:290
+#, python-format
+msgid "Warehouse is empty!"
+msgstr "倉庫は空です!"
 
 #. module: sale_order_import
 #: code:addons/sale_order_import/wizard/import_sale.py:112

--- a/sale_order_import/wizard/import_sale.py
+++ b/sale_order_import/wizard/import_sale.py
@@ -143,14 +143,14 @@ class import_sale(models.TransientModel):
                                                         'state': 'failed',
                                                         'model_id': model.id}).id
             error_line_id = self.env['error.log.line'].create({
-                                        'row_no' : row_no + 1,
+                                        'row_no' : row_no,
                                         'order_group' : order_group_value,
                                         'error_name': error_line_vals['error_name'],
                                         'log_id' : error_log_id
                                     })
         elif error_line_vals['error']:
             error_line_id = self.env['error.log.line'].create({
-                                        'row_no' : row_no + 1,
+                                        'row_no' : row_no,
                                         'order_group' : order_group_value,
                                         'error_name': error_line_vals['error_name'],
                                         'log_id' : error_log_id
@@ -265,19 +265,31 @@ class import_sale(models.TransientModel):
 
                 error_line_vals = {'error_name' : '', 'error': False}
                 partner_value = row[partner_id].strip()
-                if partner_value:
+                if not partner_value:
+                    error_line_vals['error_name'] = error_line_vals['error_name'] + _('Partner is empty!') + '\n'
+                    error_line_vals['error'] = True
+                else:
                     self._get_partner_dict(partner_value, partner_dict, error_line_vals)
                 
                 product_id_value = row[product_id].strip()
-                if product_id_value:
+                if not product_id_value:
+                    error_line_vals['error_name'] = error_line_vals['error_name'] + _('Product is empty!') + '\n'
+                    error_line_vals['error'] = True
+                else:
                     self._get_product_dict(product_id_value, product_dict, error_line_vals)
                 
                 pricelist_value = row[pricelist_id].strip()
-                if pricelist_value:
+                if not pricelist_value:
+                    error_line_vals['error_name'] = error_line_vals['error_name'] + _('Pricelist is empty!') + '\n'
+                    error_line_vals['error'] = True
+                else:
                     self._get_pricelist_dict(pricelist_value, pricelist_dict, error_line_vals)
                 
                 warehouse_value = row[warehouse_id].strip()
-                if warehouse_value:
+                if not warehouse_value:
+                    error_line_vals['error_name'] = error_line_vals['error_name'] + _('Warehouse is empty!') + '\n'
+                    error_line_vals['error'] = True
+                else:
                     self._get_picking_dict(warehouse_value, picking_dict, error_line_vals)
                 
                 taxes = []
@@ -285,14 +297,26 @@ class import_sale(models.TransientModel):
                 if tax_from_chunk:
                     self._get_taxes(tax_from_chunk, taxes, error_line_vals)
 
-                qty = float(row[product_qty].strip())
-                if qty < 0:
-                    error_line_vals['error_name'] = error_line_vals['error_name'] + _('Quantity not less then zero!') + '\n'
+                qty = row[product_qty].strip()
+                if not qty:
+                    error_line_vals['error_name'] = error_line_vals['error_name'] + _('Quantity is empty!') + '\n'
+                    error_line_vals['error'] = True
+                else:
+                    qty = float(qty)
+                
+                if qty <= 0:
+                    error_line_vals['error_name'] = error_line_vals['error_name'] + _('Quantity not less than zero!') + '\n'
                     error_line_vals['error'] = True
                 
-                price_unit_value = float(row[price_unit].strip())
-                if price_unit_value < 0:
-                    error_line_vals['error_name'] = error_line_vals['error_name'] + _('Price Unit not less then zero!') + '\n'
+                price_unit_value = row[price_unit].strip()
+                if not price_unit_value:
+                    error_line_vals['error_name'] = error_line_vals['error_name'] + _('Unit Price is empty!') + '\n'
+                    error_line_vals['error'] = True
+                else:
+                    price_unit_value = float(price_unit_value)
+                
+                if price_unit_value <= 0:
+                    error_line_vals['error_name'] = error_line_vals['error_name'] + _('Unit Price not less than zero!') + '\n'
                     error_line_vals['error'] = True
                 
                 order_policy = self.order_policy


### PR DESCRIPTION
- updated code so that error message not server error occurs when any of Partner, Product, Pricelist, Warehouse, Unit Price and Quantity is empty in Purchase/Sales Order Import modules
- updated code so that Row Number in error log shows correct row number in Purchase/Sales/Picking Import modules
- updated code to change 'Excel Row Number' to 'Row Number' in Base Import Log module
- updated translation of Purchase/Sales/Picking Import and Base Import Log modules
